### PR TITLE
black and white T265

### DIFF
--- a/urdf/_t265.gazebo.xacro
+++ b/urdf/_t265.gazebo.xacro
@@ -57,6 +57,7 @@ This is the Gazebo URDF model for the Intel RealSense T265 camera
           <image>
             <width>${fisheye_width}</width>
             <height>${fisheye_height}</height>
+            <format>L8</format>
           </image>
           <clip>
             <near>0.2</near>
@@ -117,6 +118,7 @@ This is the Gazebo URDF model for the Intel RealSense T265 camera
           <image>
             <width>${fisheye_width}</width>
             <height>${fisheye_height}</height>
+            <format>L8</format>
           </image>
           <clip>
             <near>0.1</near>


### PR DESCRIPTION
Real T265 have the color format as Y8

The L8 is the only one which is black and white and of 8 bit for gazebo sdf format